### PR TITLE
Support for unlisted/future API routes

### DIFF
--- a/lib/smartapi-connect.js
+++ b/lib/smartapi-connect.js
@@ -439,7 +439,7 @@ var SmartApi = function (params) {
     }
 
     function makeRequest(method, url, params) {
-        return request_util(route, method, params);
+        return request_util(url, method, params);
     }
 
     self.makeRequest = makeRequest;

--- a/lib/smartapi-connect.js
+++ b/lib/smartapi-connect.js
@@ -284,6 +284,19 @@ var SmartApi = function (params) {
 
     /**
      * Description
+     * @method getLTP
+     * @param {object} params
+     * @param {string} exchange (NSE or BSE)
+     * @param {string} tradingsymbol (RELIANCE-EQ, INFY-EQ, SBIN-EQ)
+     * @param {string} symboltoken
+     */
+    self.getLTP = function (params) {
+        let url = '/rest/secure/angelbroking/order/v1/getLtpData';
+        return makeRequest('POST', url, params);
+    };
+
+    /**
+     * Description
      * @method getRMS
      */
     self.getRMS = function () {
@@ -425,6 +438,12 @@ var SmartApi = function (params) {
         return post_request("candle_data", params);
     }
 
+    function makeRequest(method, url, params) {
+        return request_util(route, method, params);
+    }
+
+    self.makeRequest = makeRequest;
+
     function get_request(route, params, responseType, responseTransformer) {
         return request_util(route, "GET", params || {}, responseType, responseTransformer);
     }
@@ -434,7 +453,7 @@ var SmartApi = function (params) {
     }
 
     function request_util(route, method, params, responseType, responseTransformer) {
-        let url = API[route], payload = null;
+        let url = API[route] || route, payload = null;
 
         if (method !== "GET" || method !== "DELETE") {
             payload = params;


### PR DESCRIPTION
* created **makeRequest()** to call any API route using _method, URL and params_
* exposed the **makeRequest** on the **SmartApi** module
* added support for **getLTP** using makeRequest() method
